### PR TITLE
Fix OrgSync links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# NUVR/OrgSync Website
+# NUVR/Engage Website
 
-This repository is designed to contain all of the code for our https://nuvr.github.io/ website in plain HTML form. While it can be added to OrgSync, these pug templates have to be split into individual files for uploading.
+This repository is designed to contain all of the code for our https://nuvr.github.io/ website in plain HTML form. While it can be added to [Engage](https://neu.campuslabs.com/engage/organization/virtual-reality-organization-of-northeastern-university), these pug templates have to be split into individual files for uploading.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "nuvr-orgsync",
+    "name": "nuvr.github.io",
     "version": "1.0.0",
-    "description": "A handful of pug files that can easily be converted into HTML and uploaded to OrgSync",
+    "description": "A handful of pug files that can easily be converted into HTML and uploaded to Engage",
     "scripts": {
         "clean": "rm -rf ./dist",
         "build": "yarn build:sass && yarn build:pug && yarn build:assets",

--- a/src/views/layouts/home.pug
+++ b/src/views/layouts/home.pug
@@ -6,9 +6,9 @@
     a(href="http://eepurl.com/c8SAzL", target="_blank")
       button.btn.btn-large.btn-white
         span Join Mailing List
-    a(href="https://orgsync.com/152063/chapter", target="_blank").m-left-10
+    a(href="https://neu.campuslabs.com/engage/organization/virtual-reality-organization-of-northeastern-university", target="_blank").m-left-10
       button.btn.btn-large.btn-white.btn-outline
-        span Join OrgSync
+        span Join NEU Engage
 
 #container.content
   #logos
@@ -28,9 +28,9 @@
     .grid-item
       h3 When and where do we meet?
       p We meet weekly on Thursdays at 7PM. Our current meeting space is the Discovery Lab in Snell Library. That’s on the first floor corner next to Argo Tea. If you join our mailing list, you can stay up to date with all alerts and news related to the club.
-      a(href="https://orgsync.com/152063/chapter", target="_blank")
+      a(href="https://neu.campuslabs.com/engage/organization/virtual-reality-organization-of-northeastern-university", target="_blank")
         button.btn
-          span Join OrgSync
+          span Join Engage (Campus Labs)
 
 script(type='text/javascript').
   setActivePage('home')

--- a/src/views/layouts/join.pug
+++ b/src/views/layouts/join.pug
@@ -20,9 +20,9 @@
     .grid-item
       h2 Join Northeastern Organization
       p Add NUVR to your list of officially joined clubs. Get access to membership information and view official documentation.
-      a(href="https://orgsync.com/152063/chapter", target="_blank")
+      a(href="https://neu.campuslabs.com/engage/organization/virtual-reality-organization-of-northeastern-university", target="_blank")
         button.btn.btn-large
-          span Join OrgSync
+          span Join Engage
 
     .grid-item
       h2 View the Lab


### PR DESCRIPTION
We no longer use OrgSync, so this updates URLs to point to our new site at https://neu.campuslabs.com/engage/organization/virtual-reality-organization-of-northeastern-university